### PR TITLE
 プレゼンテーションモジュールの修正

### DIFF
--- a/presentation/src/main/java/com/whitebeach/presentation/main/MainScreen.kt
+++ b/presentation/src/main/java/com/whitebeach/presentation/main/MainScreen.kt
@@ -53,6 +53,8 @@ import com.whitebeach.presentation.formationSheet.rememberFormation
 import com.whitebeach.presentation.main.view.BottomBar
 import com.whitebeach.presentation.playerSheet.PlayerSheet
 import com.whitebeach.presentation.R
+import com.whitebeach.presentation.playerSheet.PlayerSheetCheck
+import com.whitebeach.presentation.playerSheet.RapidApiViewModel
 import dev.shreyaspatil.capturable.capturable
 import dev.shreyaspatil.capturable.controller.rememberCaptureController
 import kotlinx.coroutines.launch
@@ -69,6 +71,7 @@ fun MainScreen(
     modifier: Modifier = Modifier,
     fireStoreViewModel: FireStoreViewModel = viewModel(),
     positionStateViewModel: PositionStateViewModel = viewModel(),
+    rapidApiViewModel: RapidApiViewModel = viewModel(),
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
@@ -81,6 +84,8 @@ fun MainScreen(
     val captureController = rememberCaptureController()
     var formationBitmap: ImageBitmap? by remember { mutableStateOf(null) }
     var loadingDialogState by remember { mutableStateOf(false) }
+
+    val playersUiState = rapidApiViewModel.playersUiState
 
     if (!isItemInBounds) {
         LaunchedEffect(Unit) {
@@ -188,11 +193,10 @@ fun MainScreen(
                         openPlayerSheet = {
                             scope.launch {
                                 sheetState.show()
-
                                 bottomSheetContent = {
-                                    PlayerSheet(
+                                    PlayerSheetCheck(
                                         modifier = Modifier,
-                                        playerList = firestoreList.value
+                                        playersUiState = playersUiState
                                     )
                                 }
                             }

--- a/presentation/src/main/java/com/whitebeach/presentation/playerSheet/PlayerSheet.kt
+++ b/presentation/src/main/java/com/whitebeach/presentation/playerSheet/PlayerSheet.kt
@@ -22,19 +22,40 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberAsyncImagePainter
 import com.whitebeach.atleticolineupapp.dragAndDrop.MimeType
-import com.whitebeach.data.model.PlayerInfo
+import com.whitebeach.data.model.player.ResponseX
 import com.whitebeach.presentation.component.dragDrop.DragData
 import com.whitebeach.presentation.component.dragDrop.DragTarget
 
 @Composable
+fun PlayerSheetCheck(
+    modifier: Modifier = Modifier,
+    playersUiState: PlayersUiState
+) {
+    when (playersUiState) {
+        is PlayersUiState.Loading -> {
+            Text(text = "Loading")
+        }
+        is PlayersUiState.Success -> {
+            PlayerSheet(
+                modifier = modifier,
+                playersList = playersUiState.players
+            )
+        }
+        is PlayersUiState.Error -> {
+            Text(text = "Error")
+        }
+    }
+}
+
+
+@Composable
 fun PlayerSheet(
     modifier: Modifier = Modifier,
-    playerList: List<PlayerInfo>
+    playersList: List<ResponseX>
 ) {
     LazyHorizontalGrid(
         rows = GridCells.Fixed(2),
@@ -44,8 +65,8 @@ fun PlayerSheet(
         horizontalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         items(
-            items = playerList,
-            key = { it.number }
+            items = playersList,
+            key = { it.player.id }
         ) { item ->
             PlayerCard(
                 player = item,
@@ -57,10 +78,10 @@ fun PlayerSheet(
 
 @Composable
 fun PlayerCard(
-    player: PlayerInfo,
+    player: ResponseX,
 //    onClick: () -> Unit
 ) {
-    val imageUrl = player.image
+    val imageUrl = player.player.photo
     val painter = rememberAsyncImagePainter(model = imageUrl)
     val dragData = DragData(type = MimeType.IMAGE_JPEG, data = painter)
 
@@ -92,7 +113,7 @@ fun PlayerCard(
                     contentScale = ContentScale.FillHeight
                 )
                 Text(
-                    text = player.name,
+                    text = player.player.name,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = 8.dp)
@@ -104,12 +125,4 @@ fun PlayerCard(
             }
         }
     }
-}
-
-@Preview
-@Composable
-fun PlayerSheetPreview() {
-    val list = listOf(
-        PlayerInfo()
-    )
 }

--- a/presentation/src/main/java/com/whitebeach/presentation/playerSheet/RapidapiViewModel.kt
+++ b/presentation/src/main/java/com/whitebeach/presentation/playerSheet/RapidapiViewModel.kt
@@ -1,58 +1,41 @@
 package com.whitebeach.presentation.playerSheet
 
-import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.whitebeach.data.model.player.ResponseX
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import com.whitebeach.data.repository.PlayersRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import retrofit2.HttpException
-import java.io.IOException
+import javax.inject.Inject
 
-sealed interface PlayersUiState {
-    data class Success(val players: MutableList<ResponseX>) : PlayersUiState
-    object Error : PlayersUiState
-    object Loading : PlayersUiState
-}
-
-sealed class ResultUiState<out T> {
-    //object Idle : ResultUiState<Nothing>()
-    object Loading : ResultUiState<Nothing>()
-    data class Success<T>(val data: T) : ResultUiState<T>()
-    data class Error(val error: String) : ResultUiState<Nothing>()
-}
-
-@Stable
-class RapidApiViewModel : ViewModel() {
-//    var playersUiState: PlayersUiState by mutableStateOf(PlayersUiState.Loading)
-//        private set
-
-    private val _playersUiState =
-        MutableStateFlow<List<ResponseX>>(emptyList())
-    val playersUiState: StateFlow<List<ResponseX>> = _playersUiState.asStateFlow()
+@HiltViewModel
+class RapidApiViewModel @Inject constructor(
+    private val playersRepository: PlayersRepository
+)  : ViewModel() {
+    var playersUiState: PlayersUiState by mutableStateOf(PlayersUiState.Loading)
+        private set
 
     init {
         getPlayersInfo()
     }
 
     private fun getPlayersInfo() {
-        //_playersUiState.value = ResultUiState.Loading
         viewModelScope.launch {
-//            try {
-//                val response = PlayerApi.retrofitService.getPlayers().body()!!.response.toMutableList()
-//                response += PlayerApi.retrofitService.getPlayers2().body()!!.response
-//                response += PlayerApi.retrofitService.getPlayers3().body()!!.response
-//                if (response.isNotEmpty()) {
-//                    _playersUiState.value = response
-//                }
-//            } catch (e: IOException) {
-//                _playersUiState.value = emptyList()
-//            } catch (e: HttpException) {
-//                _playersUiState.value = emptyList()
-//            }
-//        }
+            playersUiState = PlayersUiState.Loading
+            playersUiState = try {
+                PlayersUiState.Success(playersRepository.getPlayers().body()!!.response)
+            } catch (e: Exception) {
+                PlayersUiState.Error(e.message ?: "unknown error")
+            }
         }
     }
+}
+
+sealed interface PlayersUiState {
+    object Loading : PlayersUiState
+    data class Success(val players: List<ResponseX>) : PlayersUiState
+    data class Error(val message: String) : PlayersUiState
 }


### PR DESCRIPTION
[プレゼンテーションモジュールの修正](https://github.com/write18jack/AtleticoLineupApp/commit/081c542692bd6110a292461745b6f0bbace41768)：RapidApiViewModel.kt, PlayerSheet.kt, MainScreen.ktの修正

プレゼンテーションモジュールでユニットテストを行うためrest apiで取得したデータをUIで表示させる三つのファイルを修正しました。

以上、ご確認よろしくお願いいたします。